### PR TITLE
compose to 1.4.0 and min sdk to 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("com.android.library") version "7.3.1" apply false
     id("com.android.application") version "7.3.1" apply false
     id("org.jetbrains.dokka") version "1.7.20"
-    id("org.jetbrains.compose") version "1.3.0" apply false
+    id("org.jetbrains.compose") version "1.4.0" apply false
 }
 
 allprojects {
@@ -20,10 +20,6 @@ allprojects {
         maven { url = uri("https://repo.repsy.io/mvn/chrynan/public") }
         maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
     }
-}
-
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
-    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
 }
 
 // Documentation

--- a/buildSrc/src/main/java/com.chrynan.navigation.buildSrc/LibraryConstants.kt
+++ b/buildSrc/src/main/java/com.chrynan.navigation.buildSrc/LibraryConstants.kt
@@ -7,8 +7,8 @@ object LibraryConstants {
     const val group = "com.chrynan.navigation"
     const val owner = "chrynan"
     const val repoName = "navigation"
-    const val versionName = "0.7.0"
-    const val versionCode = 9
+    const val versionName = "0.7.1"
+    const val versionCode = 10
     const val versionDescription = "Release $versionName ($versionCode)"
     const val license = "Apache-2.0"
     const val vcsUrl = "https://github.com/chRyNaN/navigation.git"
@@ -16,7 +16,7 @@ object LibraryConstants {
     object Android {
 
         const val compileSdkVersion = 33
-        const val minSdkVersion = 23
+        const val minSdkVersion = 21
         const val targetSdkVersion = 33
     }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -20,9 +20,9 @@ version.androidx.appcompat=1.6.1
 ##             # available=1.7.0-alpha01
 ##             # available=1.7.0-alpha02
 
-version.androidx.compose.compiler=1.4.3
+version.androidx.compose.compiler=1.4.4
 
-version.androidx.compose.ui=1.3.3
+version.androidx.compose.ui=1.4.0
 ##              # available=1.4.0-alpha01
 ##              # available=1.4.0-alpha02
 ##              # available=1.4.0-alpha03


### PR DESCRIPTION
- Compose / Kotlin Js now uses Node JS v18 by default