### PR TITLE
Fixed Serialization Issue #9

### DIFF
--- a/navigation-compose/build.gradle.kts
+++ b/navigation-compose/build.gradle.kts
@@ -41,9 +41,8 @@ kotlin {
                 implementation(compose.ui)
                 implementation(compose.foundation)
 
-                implementation(KotlinX.serialization.core)
-                implementation("com.chrynan.parcelable:parcelable-core:_")
-                implementation("com.chrynan.parcelable:parcelable-compose:_")
+                api("com.chrynan.parcelable:parcelable-core:_")
+                api("com.chrynan.parcelable:parcelable-compose:_")
             }
         }
         if (isBuildingOnOSX()) {

--- a/navigation-compose/src/commonMain/kotlin/com.chrynan.navigation.compose/RememberComposeNavigatorUtils.kt
+++ b/navigation-compose/src/commonMain/kotlin/com.chrynan.navigation.compose/RememberComposeNavigatorUtils.kt
@@ -147,7 +147,7 @@ fun <Destination : NavigationDestination, Context : NavigationContext<Destinatio
 inline fun <reified Destination : NavigationDestination> rememberSavableNavigator(
     initialDestination: Destination,
     parcelable: Parcelable = Parcelable.Default,
-    destinationSerializer: KSerializer<Destination> = Parcelable.serializersModule.serializer(),
+    destinationSerializer: KSerializer<Destination> = parcelable.serializersModule.serializer(),
     duplicateDestinationStrategy: NavigationStrategy.DuplicateDestination = NavigationStrategy.DuplicateDestination.ALLOW_DUPLICATES,
     backwardsNavigationStrategy: NavigationStrategy.BackwardsNavigation = NavigationStrategy.BackwardsNavigation.IN_CONTEXT,
     destinationRetentionStrategy: NavigationStrategy.DestinationRetention = NavigationStrategy.DestinationRetention.RETAIN
@@ -210,8 +210,8 @@ inline fun <reified Destination : NavigationDestination> rememberSavableNavigato
 inline fun <reified Destination : NavigationDestination, reified Context : NavigationContext<Destination>> rememberSavableNavigator(
     initialContext: Context,
     parcelable: Parcelable = Parcelable.Default,
-    destinationSerializer: KSerializer<Destination> = Parcelable.serializersModule.serializer(),
-    contextSerializer: KSerializer<Context> = Parcelable.serializersModule.serializer(),
+    destinationSerializer: KSerializer<Destination> = parcelable.serializersModule.serializer(),
+    contextSerializer: KSerializer<Context> = parcelable.serializersModule.serializer(),
     duplicateDestinationStrategy: NavigationStrategy.DuplicateDestination = NavigationStrategy.DuplicateDestination.ALLOW_DUPLICATES,
     backwardsNavigationStrategy: NavigationStrategy.BackwardsNavigation = NavigationStrategy.BackwardsNavigation.IN_CONTEXT,
     destinationRetentionStrategy: NavigationStrategy.DestinationRetention = NavigationStrategy.DestinationRetention.RETAIN

--- a/navigation-core/build.gradle.kts
+++ b/navigation-core/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
                 implementation(Kotlin.stdlib.common)
 
                 implementation(KotlinX.coroutines.core)
-                implementation(KotlinX.serialization.core)
+                api(KotlinX.serialization.core)
             }
         }
 

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     id("org.jetbrains.compose")
+    kotlin("plugin.serialization")
 }
 
 group = LibraryConstants.group
@@ -61,6 +62,8 @@ dependencies {
     implementation(AndroidX.compose.compiler)
     implementation(AndroidX.compose.ui.tooling)
     implementation(AndroidX.activity.compose)
+
+    implementation(KotlinX.coroutines.core)
 
     implementation("com.chrynan.presentation:presentation-compose:_")
     implementation("com.chrynan.colors:colors-compose:_")

--- a/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/MultipleContextSample.kt
+++ b/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/MultipleContextSample.kt
@@ -10,6 +10,7 @@ import com.chrynan.navigation.ExperimentalNavigationApi
 import com.chrynan.navigation.changeContext
 import com.chrynan.navigation.compose.NavigationContainer
 import com.chrynan.navigation.compose.rememberNavigator
+import com.chrynan.navigation.compose.rememberSavableNavigator
 import com.chrynan.navigation.goBack
 import com.chrynan.navigation.goTo
 import com.chrynan.navigation.sample.compose.composable.Items

--- a/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/NavigationComponents.kt
+++ b/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/NavigationComponents.kt
@@ -6,18 +6,28 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.chrynan.navigation.NavigationContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 sealed class AppDestination {
 
+    @Serializable
     object Home : AppDestination()
 
+    @Serializable
     object Search : AppDestination()
 
+    @Serializable
     object Settings : AppDestination()
 
-    data class Details(val itemId: Int) : AppDestination()
+    @Serializable
+    data class Details(
+        @SerialName(value = "item_id") val itemId: Int
+    ) : AppDestination()
 }
 
+@Serializable
 enum class AppContext(
     val title: String,
     val icon: ImageVector,

--- a/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/SingleContextSample.kt
+++ b/sample-compose/src/main/java/com/chrynan/navigation/sample/compose/example/SingleContextSample.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import com.chrynan.navigation.ExperimentalNavigationApi
 import com.chrynan.navigation.compose.NavigationContainer
 import com.chrynan.navigation.compose.rememberNavigator
+import com.chrynan.navigation.compose.rememberSavableNavigator
 import com.chrynan.navigation.goBack
 import com.chrynan.navigation.goTo
 import com.chrynan.navigation.sample.compose.composable.Items
@@ -21,7 +22,10 @@ fun SingleContextSample(
     modifier: Modifier = Modifier,
     onClose: () -> Unit
 ) {
-    val navigator = rememberNavigator<AppDestination>(initialDestination = AppDestination.Home)
+    val navigator = rememberSavableNavigator<AppDestination>(
+        initialDestination = AppDestination.Home,
+        destinationSerializer = AppDestination.serializer()
+    )
 
     BackHandler {
         if (!navigator.goBack()) {


### PR DESCRIPTION
This PR fixes [Issue #9](https://github.com/chRyNaN/navigation/issues/9)

## Changes

* Exposed the `kotlinx.serialization` and `com.chrynan.parcelable` dependencies so that users of the library will not have to manually include those dependencies as they are now transitive
* Fixed incorrect use of the default `Parcelable` object instead of the `parcelable` parameter value in the `rememberSavableNavigator` functions
* Manually implemented a `KSerializer` for `Navigator`
* Manually implemented serializers for `NavigationEvent` s and `NavigationEvent.Forward` sealed classes

## Issue Description

Issue #9 was occurring because of the [way kotlinx.serialization handles sealed class polymorphic serialization with generic types](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#polymorphism-and-generic-classes). The generated serializer for sealed classes with generic types, apparently requires manually registering every type that will be used with that class. This is not very flexible, so to fix this, I created a `NavigationEvent.Snapshot` class that was not serializable and contained all the values every `NavigationEvent` could have. Then I implemented custom serializers for `NavigationEvent` and its subclass `NavigationEvent.Forward` (which too is a sealed class) and delegated to the `NavigationEvent.Snapshot` generated serializer, converting that to and from the appropriate types. This seemed to solve the issue.